### PR TITLE
Fehler bei der Serialisierung behoben / Testclient hinzugefügt

### DIFF
--- a/Ident-PLUS-TestClient/App.config
+++ b/Ident-PLUS-TestClient/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
+    </startup>
+</configuration>

--- a/Ident-PLUS-TestClient/Ident-PLUS-TestClient.csproj
+++ b/Ident-PLUS-TestClient/Ident-PLUS-TestClient.csproj
@@ -1,0 +1,57 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{20DBF11F-776C-4A63-B85B-A78AEA741D20}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>Ident_PLUS_TestClient</RootNamespace>
+    <AssemblyName>Ident-PLUS-TestClient</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\IdentPlusLib\IdentPlusLib.csproj">
+      <Project>{0904bef3-ff6a-469c-95b8-f95db3b69d81}</Project>
+      <Name>IdentPlusLib</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/Ident-PLUS-TestClient/Program.cs
+++ b/Ident-PLUS-TestClient/Program.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using IdentPlusLib;
+
+namespace Ident_PLUS_TestClient
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            Console.Out.WriteLine("Ident-PLUS command line client");
+            if (args.Length != 2)
+            {
+                Console.Out.WriteLine("Usage: ident-PLUS-TestClient.exe <tcp://host:port> <token>");
+            }
+            else
+            {
+                var hostport = args[0];
+                var token = args[1];
+
+                using (var client = new IdentPlusLib.IdentPlusClient(new NetMQClient(hostport)))
+                {
+                    var task = client.IdentDatenAbrufen(new Query(token));
+                    if (task.Wait(TimeSpan.FromMilliseconds(2000)))
+                    {
+                        var reply = task.Result;
+                        if (reply is RDPInfos)
+                        {
+                            var rdp = (RDPInfos) reply;
+                            Console.Out.WriteLine($"RDP: '{rdp.Name} ({rdp.RDPUserName})' - {rdp.RDPAdresse}");
+                        }
+                        else if (reply is NotFound)
+                        {
+                            Console.Out.WriteLine("Token not found!");
+                        }
+                        else if (reply is InternalError)
+                        {
+                            var error = (InternalError) reply;
+                            Console.Out.WriteLine("Error: " + error.ErrorInfo);
+                        }
+                        else
+                        {
+                            Console.Out.WriteLine("Unexpected reply type: " + (reply.GetType().Name));
+                        }
+                    }
+                    else
+                    {
+                        Console.Out.WriteLine("Timeout!");
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Ident-PLUS-TestClient/Properties/AssemblyInfo.cs
+++ b/Ident-PLUS-TestClient/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Ident-PLUS-TestClient")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Ident-PLUS-TestClient")]
+[assembly: AssemblyCopyright("Copyright ©  2017")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("20dbf11f-776c-4a63-b85b-a78aea741d20")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Ident-PLUS.sln
+++ b/Ident-PLUS.sln
@@ -9,6 +9,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Spezifikation", "Spezifikat
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "IdentPlusLib", "IdentPlusLib\IdentPlusLib.csproj", "{0904BEF3-FF6A-469C-95B8-F95DB3B69D81}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Ident-PLUS-TestClient", "Ident-PLUS-TestClient\Ident-PLUS-TestClient.csproj", "{20DBF11F-776C-4A63-B85B-A78AEA741D20}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -27,6 +29,10 @@ Global
 		{0904BEF3-FF6A-469C-95B8-F95DB3B69D81}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0904BEF3-FF6A-469C-95B8-F95DB3B69D81}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0904BEF3-FF6A-469C-95B8-F95DB3B69D81}.Release|Any CPU.Build.0 = Release|Any CPU
+		{20DBF11F-776C-4A63-B85B-A78AEA741D20}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{20DBF11F-776C-4A63-B85B-A78AEA741D20}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{20DBF11F-776C-4A63-B85B-A78AEA741D20}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{20DBF11F-776C-4A63-B85B-A78AEA741D20}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/IdentPlusLib/DemoData.cs
+++ b/IdentPlusLib/DemoData.cs
@@ -6,9 +6,11 @@ namespace IdentPlusLib
     {
         public const string Token1 = "1";
         public const string Token2 = "2";
+        public const string TestFehlermeldung = "Angeforderter Fehler zu Testzwecken.";
 
         public static Task<Reply> Abfrage(Query query)
         {
+            if (query.Token == "DEMODATA_THROW") return Task.FromResult((Reply) new InternalError(TestFehlermeldung));
             if (query.Token == Token1) return Task.FromResult((Reply)new RDPInfos("Martina Musterfrau", "einRechner", "mm"));
             if (query.Token == Token2) return Task.FromResult((Reply)new RDPInfos("Jens Mustermann", "einandererRechner", "jm"));
             return Task.FromResult(NotFound.Instance);

--- a/IdentPlusLib/IdentPlusServer.cs
+++ b/IdentPlusLib/IdentPlusServer.cs
@@ -39,8 +39,8 @@ namespace IdentPlusLib
             var bytes = System.Text.Encoding.UTF8.GetBytes(info);
             var buffer = new Byte[4 + 4 + bytes.Length];
             Array.Copy(BitConverter.GetBytes(Constants.REPLY_ERROR), 0, buffer, 0, 4);
-            Array.Copy(BitConverter.GetBytes(bytes.Length), 0, buffer, 8, 4);
-            Array.Copy(bytes, 0, buffer, 12, bytes.Length);
+            Array.Copy(BitConverter.GetBytes(bytes.Length), 0, buffer, 4, 4);
+            Array.Copy(bytes, 0, buffer, 8, bytes.Length);
             return buffer;
         }
 

--- a/Spezifikation/IdentPlus_Testbase.cs
+++ b/Spezifikation/IdentPlus_Testbase.cs
@@ -21,5 +21,13 @@ namespace Spezifikation
             SUT()(new Query("sagdhsa785d6aszuidsa78d6tzsajkldusa78tdzhasda")).Result.Should().Be(NotFound.Instance);
         }
 
+        [Test]
+        public void Fehler_werden_uebertragen()
+        {
+            var result = SUT()(new Query("DEMODATA_THROW")).Result;
+            result.Should().BeOfType<InternalError>();
+            ((InternalError) result).ErrorInfo.Should().Be(DemoData.TestFehlermeldung);
+        }
+
     }
 }


### PR DESCRIPTION
Bei der Serialisierung von InternalError war ein Fehler im Offset um Buffer. Dadurch kam es dabei zu einer Exception. Test geschrieben, Fehler behoben.

Ich habe ein Projekt Ident-PLUS-TestClient hinzugefügt, das einen Client in einer Kommandozeilenanwendung bereitstellt, um einen laufenden Server menuell testen zu können.